### PR TITLE
feat: use Render private network between services

### DIFF
--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -14,8 +14,7 @@ RUN pip install -r requirements.txt
 EXPOSE 5000
 
 # Define environment variable
-ENV API_HOST 0.0.0.0
-ENV API_PORT 5000
+ENV API_URL 0.0.0.0:5000
 
 # Run app.py when the container launches
 CMD [ "gunicorn", "app:app" ]

--- a/backend/gunicorn.conf.py
+++ b/backend/gunicorn.conf.py
@@ -1,3 +1,3 @@
 import os
 
-bind = f"{os.environ.get("API_HOST", "0.0.0.0")}:{os.environ.get("API_PORT", "5000")}"
+bind = f"{os.environ.get("API_URL", "0.0.0.0:5000")}"

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -12,11 +12,11 @@ services:
       - backend
     # Specify environment variables
     environment:
-      REACT_APP_API_PORT: 4000 # because macOS occupies 5000
+      REACT_APP_API_URL: localhost:4000 # because macOS occupies 5000
 
   backend:
     # Specify the build context for the backend
     build: ./backend
     # Map the host port to the container port
     ports:
-      - "4000:5000"
+      - 4000:5000

--- a/frontend/Dockerfile
+++ b/frontend/Dockerfile
@@ -21,8 +21,7 @@ EXPOSE 3000
 
 # Define environment variable
 ENV REACT_APP_API_SSL false
-ENV REACT_APP_API_HOST localhost
-ENV REACT_APP_API_PORT 5000
+ENV REACT_APP_API_URL localhost:5000
 
 # Run the app when the container launches
 CMD [ "npm", "run", "start" ]

--- a/frontend/src/App.js
+++ b/frontend/src/App.js
@@ -125,8 +125,8 @@ function App() {
       // Request backend API with operands and operation type to get results
       const api_response = await axios.post(
         `http${process.env.REACT_APP_API_SSL === "true" ? "s" : ""}://${
-          process.env.REACT_APP_API_HOST || "localhost"
-        }:${process.env.REACT_APP_API_PORT || 5000}/api/${current_operation}`,
+          process.env.REACT_APP_API_URL || "localhost:5000"
+        }/api/${current_operation}`,
         request_payload
       );
       // Format the returned result from API in case if large number
@@ -190,8 +190,8 @@ function App() {
       // Request backend API with operand and operation type to get results
       const api_response = await axios.post(
         `http${process.env.REACT_APP_API_SSL === "true" ? "s" : ""}://${
-          process.env.REACT_APP_API_HOST || "localhost"
-        }:${process.env.REACT_APP_API_PORT || 5000}/api/${api_endpoint}`,
+          process.env.REACT_APP_API_URL || "localhost:5000"
+        }/api/${api_endpoint}`,
         request_payload
       );
       // Format the returned result from API in case if large number

--- a/render.yaml
+++ b/render.yaml
@@ -21,15 +21,10 @@ services:
     envVars:
       - key: REACT_APP_API_SSL
         value: true
-      - key: REACT_APP_API_PORT
+      - key: REACT_APP_API_URL
         fromService:
           name: cycalc-backend
           type: web
-          property: port
-      - key: REACT_APP_API_HOST
-        fromService:
-          name: cycalc-backend
-          type: web
-          property: host
+          property: hostport
     domains:
       - calc.cybar.dev

--- a/render.yaml
+++ b/render.yaml
@@ -22,8 +22,14 @@ services:
       - key: REACT_APP_API_SSL
         value: true
       - key: REACT_APP_API_PORT
-        value: 443
+        fromService:
+          name: cycalc-backend
+          type: web
+          property: port
       - key: REACT_APP_API_HOST
-        sync: false
+        fromService:
+          name: cycalc-backend
+          type: web
+          property: host
     domains:
       - calc.cybar.dev


### PR DESCRIPTION
- Currently we're invoking the public URL of the backend service when making requests from the frontend service.
- This PR makes the frontend call the backend via the private network URL that Render automatically creates.
- It's more automatically managed in the Render Blueprint.
---
## Tasks
- [x] Update Render Blueprint
- [x] Update Docker Compose config
- [x] Update `Dockerfile` (backend)
- [x] Update `Dockerfile` (frontend)
- [x] Update `App.js` with new env var
- [x] Update `gunicorn.config.py` with new env car